### PR TITLE
add http proxy option to request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,14 @@ module.exports = {
 						return done();
 					}
 
-					request( host + name )
+					var options = {
+						url: host + name,
+					};
+					if (process.env.http_proxy != null) {
+						options.proxy = process.env.http_proxy;
+					};
+					
+					request( options )
 						.on( 'error', function( err ) {
 							logger.error( 'Error while downloading', name );
 							logger.error( err );


### PR DESCRIPTION
Thank you for your sharing.
It is very helpful for me.

When I using `bender server` command(behind cooperate proxy),
There are errors..

``` bash
error: [jquery] Error while downloading jquery-1.8.3.js
error: [jquery]  Error: connect ETIMEDOUT 94.31.29.53:80
    at Object.exports._errnoException (util.js:856:11)
    at exports._exceptionWithHostPort (util.js:879:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1062:14)
```

So I added this code to set a proxy option.

Thanks for your review!
